### PR TITLE
Fix: Lazy injection for continued sessions + fix npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 # Temporary folders
 tmp/
 temp/
+
+# Local documentation (fork-specific)
+AGENTS.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,16 +7,27 @@
     "": {
       "name": "psychmem",
       "version": "1.0.3",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
+        "better-sqlite3": "^12.6.2",
+        "uuid": "^13.0.0"
+      },
+      "bin": {
+        "psychmem": "dist/cli.js"
+      },
+      "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.2.3",
-        "@types/uuid": "^11.0.0",
-        "better-sqlite3": "^12.6.2",
         "esbuild": "^0.27.3",
-        "sqlite-vec": "^0.1.7-alpha.2",
-        "typescript": "^5.9.3",
-        "uuid": "^13.0.0"
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opencode-ai/plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -26,6 +37,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -41,6 +53,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -56,6 +69,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -71,6 +85,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -86,6 +101,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -101,6 +117,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -116,6 +133,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -131,6 +149,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -146,6 +165,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -161,6 +181,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -176,6 +197,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -191,6 +213,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -206,6 +229,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -221,6 +245,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -236,6 +261,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -251,6 +277,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -266,6 +293,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -281,6 +309,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -296,6 +325,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -311,6 +341,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -326,6 +357,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -341,6 +373,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -356,6 +389,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -371,6 +405,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -386,6 +421,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -401,6 +437,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -413,6 +450,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -421,17 +459,9 @@
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "uuid": "*"
       }
     },
     "node_modules/base64-js": {
@@ -554,6 +584,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -824,78 +855,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/sqlite-vec": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==",
-      "optionalDependencies": {
-        "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
-        "sqlite-vec-darwin-x64": "0.1.7-alpha.2",
-        "sqlite-vec-linux-arm64": "0.1.7-alpha.2",
-        "sqlite-vec-linux-x64": "0.1.7-alpha.2",
-        "sqlite-vec-windows-x64": "0.1.7-alpha.2"
-      }
-    },
-    "node_modules/sqlite-vec-darwin-arm64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-darwin-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-arm64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-windows-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -953,6 +912,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -964,7 +924,8 @@
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",


### PR DESCRIPTION
# Fix: Lazy injection for continued sessions + fix npm install

## 📋 Summary

This PR implements two critical fixes for PsychMem:

1. **Lazy Injection for Continued Sessions** - Users using `opencode -c` now receive memory injections
2. **Fix npm install** - `"plugin": ["psychmem"]` now works without crashing OpenCode

---

## 🐛 Problem 1: Continued sessions without memory injections

### What was happening
- Users use `opencode -c` for ~90% of sessions (continued sessions)
- PsychMem only injected memories on `session.created` event (new sessions only)
- Continued sessions NEVER received memory injections
- Users lost all previous context/decisions/bugs in continued sessions

### Root cause
- PsychMem tracked injected sessions but had no mechanism to inject into continued sessions
- The `session.created` event is NOT fired for continued sessions (by design)
- No hook point existed for lazy injection on first user message

### Solution: Lazy Injection
Added `injectedSessions: Set<string>` to track which sessions have received injection.

### Behavior after fix

| Scenario | Before | After |
|----------|--------|-------|
| New session | Injection on `session.created` ✅ | Injection on `session.created` ✅ |
| Continued session, only reading | NO injection ❌ | NO injection ❌ |
| Continued session, first user prompt | NO injection ❌ | **Lazy injection** ✅ |
| Continued session, subsequent prompts | NO injection ❌ | NO injection ✅ |

---

## 🐛 Problem 2: npm install crashes OpenCode

### What was happening
Error when using `"plugin": ["psychmem"]` in `opencode.jsonc`:

```
TypeError: Cannot call a class constructor ClaudeCodeAdapter without |new|
```

### Root cause
- OpenCode loads `"plugin": ["psychmem"]` → imports `main` (`dist/index.js`)
- `dist/index.js` exports CLASSES, NOT a plugin function
- OpenCode tries to call the imported module as a function → TypeError

### Solution: Default export for npm
Added **default export** to `src/index.ts` that returns a plugin function:

```typescript
export default async function PsychMemPlugin(ctx: OpenCodePluginContext) {
  // ... returns createOpenCodePlugin(ctx, config)
}
```

This matches the existing `plugin.js` entry point and works correctly with npm plugin loading.

---

## ✅ Testing

Tested with `npm link` → `"plugin": ["psychmem"]`:

- ✅ OpenCode starts without errors
- ✅ New sessions receive memory injection on `session.created`
- ✅ Continued sessions receive lazy injection on **first user message**
- ✅ Log confirms: `Lazy injection: first user message in session <id>`

---

## 📝 Files changed

| File | Lines | Description |
|-------|--------|-------------|
| `src/adapters/opencode/index.ts` | +29 | Lazy injection implementation |
| `src/index.ts` | +73 | Default export for npm install fix |
| `.gitignore` | +3 | Ignore AGENTS.md |
| `package-lock.json` | ~137 | Fix stale lockfile |

---

## 📖 Related

- Closes: Continued sessions not receiving memory injections
- Closes: npm install crash when loading via opencode.jsonc