### PR TITLE
fix: prevent Bun from eagerly resolving node:sqlite import

### DIFF
--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -90,7 +90,10 @@ async function createBunDatabase(dbPath: string): Promise<SqliteDatabase> {
  */
 async function createNodeDatabase(dbPath: string): Promise<SqliteDatabase> {
   // node:sqlite is synchronous — dynamic import keeps the async adapter signature uniform
-  const { DatabaseSync } = await import('node:sqlite' as string);
+  // Use a computed string to prevent Bun's static resolver from eagerly resolving this
+  // (Bun fails on 'node:sqlite' even in unreachable code paths)
+  const nodesqlite = 'node:' + 'sqlite';
+  const { DatabaseSync } = await import(nodesqlite);
   const db = new DatabaseSync(dbPath);
 
   return {


### PR DESCRIPTION
## Summary

- Bun's static resolver eagerly analyzes `import('node:sqlite')` at parse time, even in code paths guarded by `isBun()` that never execute under Bun
- This causes `"Could not resolve: node:sqlite"` errors when psychmem runs under Bun-based runtimes like OpenCode
- Replace the static string literal with a computed string (`'node:' + 'sqlite'`) to prevent Bun's static resolution
- The existing `as string` TypeScript cast was insufficient since it gets stripped during compilation

## Error reproduced

```
error: Could not resolve: "node:sqlite". Maybe you need to "bun install"?
    at .../node_modules/psychmem/dist/storage/sqlite-adapter.js:67:43
```

## Test plan

- [x] Verified the fix resolves the error on OpenCode v1.2.10 (Bun 1.2) on Linux
- [ ] Confirm `node:sqlite` still works correctly under Node.js 22+
- [ ] Confirm `bun:sqlite` path still works correctly under Bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)